### PR TITLE
Filter pathways to only include Reactome entries; update endpoint nam…

### DIFF
--- a/src/components/PathwayCardContainer.tsx
+++ b/src/components/PathwayCardContainer.tsx
@@ -5,7 +5,7 @@ import useApi from "./UseApi";
 import PathwayCard, { PathwayData } from "./PathwayCard";
 
 const PathwayCardContainer: FunctionComponent<RouteComponentProps<any>> = ({
-  match
+  match,
 }) => {
   const { id } = match.params;
   const { data } = useApi(
@@ -21,9 +21,11 @@ const PathwayCardContainer: FunctionComponent<RouteComponentProps<any>> = ({
           {data.results.length} pathways for {id}
         </h2>
       </div>
-      {data.results.map((item: PathwayData) => (
-        <PathwayCard data={item} key={v1()} />
-      ))}
+      {data.results
+        .filter((item: PathwayData) => item.dbType === "Reactome")
+        .map((item: PathwayData) => (
+          <PathwayCard data={item} key={v1()} />
+        ))}
     </Fragment>
   );
 };

--- a/src/components/PathwayCardContainer.tsx
+++ b/src/components/PathwayCardContainer.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, FunctionComponent } from "react";
+import React, { Fragment, FunctionComponent, ReactElement } from "react";
 import { withRouter, RouteComponentProps } from "react-router";
 import { v1 } from "uuid";
 import useApi from "./UseApi";
@@ -14,6 +14,12 @@ const PathwayCardContainer: FunctionComponent<RouteComponentProps<any>> = ({
   if (!data) {
     return null;
   }
+  let pathwayCardNodes: ReactElement[] = [];
+  data.results.forEach((item: PathwayData) => {
+    if (item.dbType === "Reactome") {
+      pathwayCardNodes.push(<PathwayCard data={item} key={v1()} />);
+    }
+  });
   return (
     <Fragment>
       <div className="page-header">
@@ -21,11 +27,7 @@ const PathwayCardContainer: FunctionComponent<RouteComponentProps<any>> = ({
           {data.results.length} pathways for {id}
         </h2>
       </div>
-      {data.results
-        .filter((item: PathwayData) => item.dbType === "Reactome")
-        .map((item: PathwayData) => (
-          <PathwayCard data={item} key={v1()} />
-        ))}
+      {pathwayCardNodes}
     </Fragment>
   );
 };

--- a/src/components/ProteinCard.tsx
+++ b/src/components/ProteinCard.tsx
@@ -21,7 +21,7 @@ export type ProteinData = {
     }
   ];
   diseases?: { diseaseName: string; note: string }[];
-  xrefs?: string[];
+  pathways?: string[];
   interactions?: string[];
   variants?: string[];
 };
@@ -38,16 +38,16 @@ const generateProteinLinks = (proteinItem: ProteinData) => {
         proteinItem.interactions.length > 1 ? "s" : ""
       }`,
       link: `/${Context.INTERACTION}/${proteinItem.accession}`,
-      color: color.INTERACTION
+      color: color.INTERACTION,
     });
   }
-  if (proteinItem.xrefs && proteinItem.xrefs.length > 0) {
+  if (proteinItem.pathways && proteinItem.pathways.length > 0) {
     proteinLinks.push({
-      name: `${proteinItem.xrefs.length} pathway${
-        proteinItem.xrefs.length > 1 ? "s" : ""
+      name: `${proteinItem.pathways.length} pathway${
+        proteinItem.pathways.length > 1 ? "s" : ""
       }`,
       link: `/${Context.PATHWAY}/${proteinItem.accession}`,
-      color: color.PATHWAY
+      color: color.PATHWAY,
     });
   }
   if (proteinItem.variants && proteinItem.variants.length > 0) {
@@ -56,7 +56,7 @@ const generateProteinLinks = (proteinItem: ProteinData) => {
         proteinItem.variants.length > 1 ? "s" : ""
       }`,
       link: `/${Context.VARIANT}/${proteinItem.accession}`,
-      color: color.VARIANT
+      color: color.VARIANT,
     });
   }
   if (proteinItem.diseases && proteinItem.diseases.length > 0) {
@@ -65,7 +65,7 @@ const generateProteinLinks = (proteinItem: ProteinData) => {
         proteinItem.diseases.length > 1 ? "s" : ""
       }`,
       link: `/${Context.DISEASE}/${proteinItem.accession}`,
-      color: color.DISEASE
+      color: color.DISEASE,
     });
   }
   return proteinLinks;
@@ -73,7 +73,7 @@ const generateProteinLinks = (proteinItem: ProteinData) => {
 
 const ProteinCard: FunctionComponent<{ data: ProteinData; id: string }> = ({
   data,
-  id
+  id,
 }) => {
   const diseaseNotes =
     data.diseases &&


### PR DESCRIPTION
…e change xrefs --> pathways.

Only reactome pathways should be shown on the disease pages. The disease and proteins API endpoint has been changed by backend so that xrefs has become pathways and all of the entries are reactome. Update front-end code to reflect these changes.